### PR TITLE
Definitly fix the problem of KiRi generated file being exclude from jekyll website

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -22,8 +22,7 @@ exclude:
   - commitlint.config.js
 
 include:
-  - kiri-light/**
-  - kiri-dark/**
+  - _KIRI_
 
 just_the_docs:
   logo: "/assets/images/logo.png"


### PR DESCRIPTION
KiRi generates files that are stored under a _KIRI_ directory. Directory starting by underscore are excluded from the builded site by default.

Added an option to specifically includes files from KiRi 